### PR TITLE
style(tetris-block): 调整方块样式

### DIFF
--- a/src/components/solid/home-block/tetris-block/index.css
+++ b/src/components/solid/home-block/tetris-block/index.css
@@ -8,17 +8,7 @@
 	gap: 12px;
 	border-radius: 1.5rem;
 	cursor: pointer;
-	transition: all 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-}
-
-.app-card::before {
-	content: "";
-	position: absolute;
-	inset: 0;
-	margin: auto;
-	border-radius: 1.5rem;
 	background: linear-gradient(-45deg, #e81cff 0%, #40c9ff 100%);
-	pointer-events: none;
 	transition: all 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 
@@ -39,10 +29,6 @@
 
 .app-card:hover::after {
 	filter: blur(30px);
-}
-
-.app-card:hover::before {
-	/* transform: rotate(-90deg) scale(1.2); */
 }
 
 .app-card:hover {


### PR DESCRIPTION
- 移除 .app-card 的 transition 属性
- 将背景渐变直接应用于 .app-card
- 删除未使用的 ::before 伪元素样式
- 优化鼠标悬停效果，仅保留方块旋转和缩放